### PR TITLE
Fallback release name to tag name

### DIFF
--- a/assets/js/releases.js
+++ b/assets/js/releases.js
@@ -36,10 +36,10 @@ jQuery(function($) {
                 .addClass(!selectStable ? 'fa-dot-circle' : 'fa-circle');
 
             $('#stable-release + .option-info')
-                .html('<b>v' + stable.name + '</b> from ' + new Date(stable.published_at).toLocaleDateString() +
+                .html('<b>v' + (stable.name || stable.tag_name) + '</b> from ' + new Date(stable.published_at).toLocaleDateString() +
                     ' <a href="' + stable.html_url + '">Release notes</a>.');
             $('#dev-release + .option-info')
-                .html('<b>v' + dev.name + '</b> from ' + new Date(dev.published_at).toLocaleDateString() +
+                .html('<b>v' + (dev.name || dev.tag_name) + '</b> from ' + new Date(dev.published_at).toLocaleDateString() +
                     ' <a href="' + dev.html_url + '">Release notes</a>.');
 
             var aurLink = selectStable ? 'https://aur.archlinux.org/packages/ulauncher/' :


### PR DESCRIPTION
Release name is optional for git,. If you don't fill it in, the Releases will use the tag name as the title. If you build Travis from a git tag (non-release) it will convert it to a releases without a name.

I have not actually tested this myself, but it's pretty easy to follow the code.